### PR TITLE
Distinguish ast from expression

### DIFF
--- a/src/Elastic.elm
+++ b/src/Elastic.elm
@@ -1,6 +1,6 @@
 module Elastic exposing
     ( parseQuery
-    , serializeExpr
+    , serialize
     )
 
 {-| Parse and serialize [ElasticSearch](https://www.elastic.co/en) search query strings.
@@ -28,7 +28,7 @@ into an [AST](https://en.wikipedia.org/wiki/Abstract_syntax_tree).
 
 import Elastic.Expression exposing (Expr)
 import Elastic.Parser exposing (parse)
-import Elastic.Serializer as Serializer exposing (run)
+import Elastic.Serializer as Serializer
 import Parser exposing (DeadEnd)
 
 
@@ -52,6 +52,6 @@ Options:
     be treated as `(foo bar) | (foo baz)`.
 
 -}
-serializeExpr : { explicitOr : Bool } -> Expr -> String
-serializeExpr config expr =
-    run (Serializer.Config config) expr
+serialize : Expr -> String
+serialize expr =
+    Serializer.run expr

--- a/src/Elastic/Ast.elm
+++ b/src/Elastic/Ast.elm
@@ -12,43 +12,47 @@ type Ast
     | Word String
 
 
-joinAnd : Ast -> Ast -> List Expr -> List Expr
-joinAnd first second acc =
-    case ( first, second ) of
-        ( And a b, And c d ) ->
-            List.concat [ acc, joinAnd a b acc, joinAnd c d acc ]
+isAnd : Ast -> Maybe ( Ast, Ast )
+isAnd ast =
+    case ast of
+        And a b ->
+            Just ( a, b )
 
-        ( And a b, y ) ->
-            List.concat [ acc, joinAnd a b acc, [ toExpr y ] ]
-
-        ( x, And c d ) ->
-            List.concat [ acc, [ toExpr x ], joinAnd c d acc ]
-
-        ( x, y ) ->
-            [ toExpr x, toExpr y ]
+        _ ->
+            Nothing
 
 
-joinOr : Ast -> Ast -> List Expr -> List Expr
-joinOr first second acc =
-    case ( first, second ) of
-        ( Or a b, Or c d ) ->
-            List.concat [ acc, joinOr a b acc, joinOr c d acc ]
+isOr : Ast -> Maybe ( Ast, Ast )
+isOr ast =
+    case ast of
+        Or a b ->
+            Just ( a, b )
 
-        ( Or a b, y ) ->
-            List.concat [ acc, joinOr a b acc, [ toExpr y ] ]
+        _ ->
+            Nothing
 
-        ( x, Or c d ) ->
-            List.concat [ acc, [ toExpr x ], joinOr c d acc ]
 
-        ( x, y ) ->
-            [ toExpr x, toExpr y ]
+join : (Ast -> Maybe ( Ast, Ast )) -> Ast -> Ast -> List Expr -> List Expr
+join isOperator first second acc =
+    case ( isOperator first, isOperator second ) of
+        ( Just ( a, b ), Just ( c, d ) ) ->
+            List.concat [ acc, join isOperator a b acc, join isOperator c d acc ]
+
+        ( Just ( a, b ), Nothing ) ->
+            List.concat [ acc, join isOperator a b acc, [ toExpr second ] ]
+
+        ( Nothing, Just ( c, d ) ) ->
+            List.concat [ acc, [ toExpr first ], join isOperator c d acc ]
+
+        ( Nothing, Nothing ) ->
+            [ toExpr first, toExpr second ]
 
 
 toExpr : Ast -> Expr
 toExpr expr =
     case expr of
         And first second ->
-            Expr.And (joinAnd first second [])
+            Expr.And (join isAnd first second [])
 
         Exact string ->
             Expr.Exact string
@@ -57,7 +61,7 @@ toExpr expr =
             Expr.Exclude (toExpr first)
 
         Or first second ->
-            Expr.Or (joinOr first second [])
+            Expr.Or (join isOr first second [])
 
         Prefix string ->
             Expr.Prefix string

--- a/src/Elastic/Ast.elm
+++ b/src/Elastic/Ast.elm
@@ -1,0 +1,66 @@
+module Elastic.Ast exposing (Ast(..), toExpr)
+
+import Elastic.Expression as Expr exposing (Expr)
+
+
+type Ast
+    = And Ast Ast
+    | Exact String
+    | Exclude Ast
+    | Or Ast Ast
+    | Prefix String
+    | Word String
+
+
+joinAnd : Ast -> Ast -> List Expr -> List Expr
+joinAnd first second acc =
+    case ( first, second ) of
+        ( And a b, And c d ) ->
+            List.concat [ acc, joinAnd a b acc, joinAnd c d acc ]
+
+        ( And a b, y ) ->
+            List.concat [ acc, joinAnd a b acc, [ toExpr y ] ]
+
+        ( x, And c d ) ->
+            List.concat [ acc, [ toExpr x ], joinAnd c d acc ]
+
+        ( x, y ) ->
+            [ toExpr x, toExpr y ]
+
+
+joinOr : Ast -> Ast -> List Expr -> List Expr
+joinOr first second acc =
+    case ( first, second ) of
+        ( Or a b, Or c d ) ->
+            List.concat [ acc, joinOr a b acc, joinOr c d acc ]
+
+        ( Or a b, y ) ->
+            List.concat [ acc, joinOr a b acc, [ toExpr y ] ]
+
+        ( x, Or c d ) ->
+            List.concat [ acc, [ toExpr x ], joinOr c d acc ]
+
+        ( x, y ) ->
+            [ toExpr x, toExpr y ]
+
+
+toExpr : Ast -> Expr
+toExpr expr =
+    case expr of
+        And first second ->
+            Expr.And (joinAnd first second [])
+
+        Exact string ->
+            Expr.Exact string
+
+        Exclude first ->
+            Expr.Exclude (toExpr first)
+
+        Or first second ->
+            Expr.Or (joinOr first second [])
+
+        Prefix string ->
+            Expr.Prefix string
+
+        Word string ->
+            Expr.Word string

--- a/src/Elastic/Expression.elm
+++ b/src/Elastic/Expression.elm
@@ -1,8 +1,6 @@
 module Elastic.Expression exposing (Expr(..))
 
-{-| Elastic Expression
-
-Expr can help you to define kind of syntax like And, Or, ....
+{-| ElasticSearch query expression.
 
 
 # Definition
@@ -12,31 +10,12 @@ Expr can help you to define kind of syntax like And, Or, ....
 -}
 
 
-{-| An `Expr` Type represent all AST's branchs
-
-    type AST
-        = And AST AST
-        | Or AST AST
-        | Exclude AST
-        | Exact String
-        | Word String
-        | Prefix String
-
-In our case, to follow the production rules `AST` will be `Expr`
-
-    type Expr
-        = And Expr Expr
-        | Exact String
-        | Exclude Expr
-        | Or Expr Expr
-        | Prefix String
-        | Word String
-
+{-| An ElasticSearh expression.
 -}
 type Expr
-    = And Expr Expr
+    = And (List Expr)
     | Exact String
     | Exclude Expr
-    | Or Expr Expr
+    | Or (List Expr)
     | Prefix String
     | Word String

--- a/src/Elastic/Serializer.elm
+++ b/src/Elastic/Serializer.elm
@@ -1,49 +1,45 @@
-module Elastic.Serializer exposing (Config(..), run)
+module Elastic.Serializer exposing (run)
 
 import Elastic.Expression exposing (Expr(..))
 
 
-type Config
-    = Config { explicitOr : Bool }
-
-
-group : Config -> Expr -> String
-group config expr =
+group : Expr -> String
+group expr =
     case expr of
-        Or _ _ ->
-            "(" ++ run config expr ++ ")"
+        Or _ ->
+            "(" ++ run expr ++ ")"
 
         _ ->
-            run config expr
+            run expr
 
 
-exclude : Config -> Expr -> String
-exclude config expr =
+exclude : Expr -> String
+exclude expr =
     case expr of
-        And _ _ ->
-            group config expr
+        And _ ->
+            group expr
 
-        Or _ _ ->
-            group config expr
+        Or _ ->
+            group expr
 
         _ ->
-            run config expr
+            run expr
 
 
-run : Config -> Expr -> String
-run ((Config { explicitOr }) as config) expr =
+run : Expr -> String
+run expr =
     case expr of
-        And first second ->
-            group config first ++ " " ++ group config second
+        And children ->
+            children |> List.map group |> String.join " "
 
         Exclude first ->
-            "-" ++ exclude config first
+            "-" ++ exclude first
 
         Exact string ->
             "\"" ++ string ++ "\""
 
-        Or first second ->
-            group config first ++ " | " ++ group config second
+        Or children ->
+            children |> List.map group |> String.join " | "
 
         Prefix string ->
             string ++ "*"

--- a/src/Elastic/Serializer.elm
+++ b/src/Elastic/Serializer.elm
@@ -9,14 +9,9 @@ type Config
 
 group : Config -> Expr -> String
 group config expr =
-    "(" ++ run config expr ++ ")"
-
-
-and : Config -> Expr -> String
-and config expr =
     case expr of
         Or _ _ ->
-            group config expr
+            "(" ++ run config expr ++ ")"
 
         _ ->
             run config expr
@@ -38,21 +33,17 @@ exclude config expr =
 run : Config -> Expr -> String
 run ((Config { explicitOr }) as config) expr =
     case expr of
-        And expr_ expr2 ->
-            and config expr_ ++ " " ++ and config expr2
+        And first second ->
+            group config first ++ " " ++ group config second
 
-        Exclude expr_ ->
-            "-" ++ exclude config expr_
+        Exclude first ->
+            "-" ++ exclude config first
 
         Exact string ->
             "\"" ++ string ++ "\""
 
-        Or expr_ expr2 ->
-            if explicitOr then
-                "(" ++ run config expr_ ++ ") | (" ++ run config expr2 ++ ")"
-
-            else
-                run config expr_ ++ " | " ++ run config expr2
+        Or first second ->
+            group config first ++ " | " ++ group config second
 
         Prefix string ->
             string ++ "*"

--- a/src/Elastic/Serializer.elm
+++ b/src/Elastic/Serializer.elm
@@ -6,6 +6,9 @@ import Elastic.Expression exposing (Expr(..))
 group : Expr -> String
 group expr =
     case expr of
+        And _ ->
+            "(" ++ run expr ++ ")"
+
         Or _ ->
             "(" ++ run expr ++ ")"
 

--- a/tests/ParserTest.elm
+++ b/tests/ParserTest.elm
@@ -79,5 +79,9 @@ suite =
                 \_ ->
                     parseQuery "(hello)bye"
                         |> Expect.err
+            , test "should handle ambiguous operator precendence" <|
+                \_ ->
+                    parseQuery "a b | a c"
+                        |> Expect.equal (Ok (Or [ And [ Word "a", Word "b" ], And [ Word "a", Word "c" ] ]))
             ]
         ]

--- a/tests/ParserTest.elm
+++ b/tests/ParserTest.elm
@@ -40,26 +40,32 @@ suite =
             , test "should return an OR expression" <|
                 \_ ->
                     parseQuery "tomatoes | cheese"
-                        |> expect (Or (Word "tomatoes") (Word "cheese")) "Error to parse Or expression"
+                        |> expect (Or [ Word "tomatoes", Word "cheese" ]) "Error to parse Or expression"
             , describe "should return an And expression"
                 [ test "with spaces as delimiter" <|
                     \_ ->
                         parseQuery "tomatoes cheese"
-                            |> expect (And (Word "tomatoes") (Word "cheese")) "Error to parse And expression with spaces as delimiter"
+                            |> expect (And [ Word "tomatoes", Word "cheese" ]) "Error to parse And expression with spaces as delimiter"
                 , test "with + as delimiter" <|
                     \_ ->
                         parseQuery "tomatoes + cheese"
-                            |> expect (And (Word "tomatoes") (Word "cheese")) "Error to parse And expression with + as delimiter"
+                            |> expect (And [ Word "tomatoes", Word "cheese" ]) "Error to parse And expression with + as delimiter"
                 ]
             , describe "should return a group of expression"
                 [ test "with no spaces between expression" <|
                     \_ ->
                         parseQuery "tomatoes (cheese | pickle)"
-                            |> expect (And (Word "tomatoes") (Or (Word "cheese") (Word "pickle"))) "Error to parse a group of expression with no spaces between expression"
+                            |> expect (And [ Word "tomatoes", Or [ Word "cheese", Word "pickle" ] ]) "Error to parse a group of expression with no spaces between expression"
                 , test "with spaces between expression" <|
                     \_ ->
                         parseQuery "( ( \"demandé à\" | \"allais\" | \"devais\" ) \"être\" )"
-                            |> expect (And (Or (Or (Exact "demandé à") (Exact "allais")) (Exact "devais")) (Exact "être")) "Error to parse"
+                            |> expect
+                                (And
+                                    [ Or [ Exact "demandé à", Exact "allais", Exact "devais" ]
+                                    , Exact "être"
+                                    ]
+                                )
+                                "Error to parse"
                 ]
             , test "should failed if the string is empty" <|
                 \_ ->

--- a/tests/SerializerTest.elm
+++ b/tests/SerializerTest.elm
@@ -44,7 +44,7 @@ suite =
         , test "should serialize a nested AND group expression into a string" <|
             \_ ->
                 Elastic.serialize (Or [ Prefix "big", And [ Word "potatoes", Word "ketchup", Word "mayo" ] ])
-                    |> Expect.equal "big* | potatoes ketchup mayo"
+                    |> Expect.equal "big* | (potatoes ketchup mayo)"
         , test "should serialize a nested OR group expression into a string" <|
             \_ ->
                 Elastic.serialize
@@ -56,5 +56,9 @@ suite =
                             ]
                         ]
                     )
-                    |> Expect.equal "(potatoes | fries) onions (ketchup | mayo)"
+                    |> Expect.equal "(potatoes | fries) (onions (ketchup | mayo))"
+        , test "should handle anbiguous operator precedence" <|
+            \_ ->
+                Elastic.serialize (Or [ And [ Word "a", Word "b" ], And [ Word "a", Word "c" ] ])
+                    |> Expect.equal "(a b) | (a c)"
         ]

--- a/tests/SerializerTest.elm
+++ b/tests/SerializerTest.elm
@@ -1,120 +1,60 @@
 module SerializerTest exposing (suite)
 
-import Elastic exposing (serializeExpr)
+import Elastic
 import Elastic.Expression exposing (Expr(..))
 import Expect exposing (Expectation)
 import Test exposing (..)
 
 
-serializeExprWithExplicitOr : Expr -> String
-serializeExprWithExplicitOr =
-    serializeExpr { explicitOr = True }
-
-
-serializeExprWithOutExplicitOr : Expr -> String
-serializeExprWithOutExplicitOr =
-    serializeExpr { explicitOr = False }
-
-
 suite : Test
 suite =
     describe "Elastic"
-        [ describe "serializeExpr with explicitOr"
-            [ test "should serialize an Word expression into string" <|
-                \_ ->
-                    serializeExprWithExplicitOr (Word "hamburger")
-                        |> Expect.equal "hamburger"
-            , test "should serialize an Prefix expression into string" <|
-                \_ ->
-                    serializeExprWithExplicitOr (Prefix "hamburger")
-                        |> Expect.equal "hamburger*"
-            , test "should serialize an Exclude expression with a Word expression into string" <|
-                \_ ->
-                    serializeExprWithExplicitOr (Exclude (Word "hamburger"))
-                        |> Expect.equal "-hamburger"
-            , test "should serialize an Exclude expression with a Prefix expression into string" <|
-                \_ ->
-                    serializeExprWithExplicitOr (Exclude (Prefix "big"))
-                        |> Expect.equal "-big*"
-            , test "should serialize an Exclude expression with a group expression into string" <|
-                \_ ->
-                    serializeExprWithExplicitOr (Exclude (Or (Prefix "big") (Exact "french fries")))
-                        |> Expect.equal "-(big* | \"french fries\")"
-            , test "should serialize an And Expression into string" <|
-                \_ ->
-                    serializeExprWithExplicitOr (And (Word "hamburger") (Prefix "cheese"))
-                        |> Expect.equal "hamburger cheese*"
-            , test "should serialize a Or expression with implicit parenthesis into string" <|
-                \_ ->
-                    serializeExprWithExplicitOr (Or (Prefix "bread") (Exclude (Word "vegetable")))
-                        |> Expect.equal "bread* | -vegetable"
-            , test "should serialize a group expression into a string" <|
-                \_ ->
-                    serializeExprWithExplicitOr (And (Prefix "big") (Or (Word "potatoes") (Exact "french fries")))
-                        |> Expect.equal "big* (potatoes | \"french fries\")"
-            , test "should serialize a nested AND group expression into a string" <|
-                \_ ->
-                    serializeExprWithExplicitOr (Or (Prefix "big") (And (Word "potatoes") (And (Word "ketchup") (Word "mayo"))))
-                        |> Expect.equal "big* | potatoes ketchup mayo"
-            , test "should serialize a nested OR group expression into a string" <|
-                \_ ->
-                    serializeExprWithExplicitOr
-                        (And
-                            (Or (Word "potatoes") (Word "fries"))
-                            (And
-                                (Word "onions")
-                                (Or (Word "ketchup") (Word "mayo"))
-                            )
-                        )
-                        |> Expect.equal "(potatoes | fries) onions (ketchup | mayo)"
-            ]
-        , describe "serializeExpr without explicitOr"
-            [ test "should serialize an Word expression into string" <|
-                \_ ->
-                    serializeExprWithOutExplicitOr (Word "hamburger")
-                        |> Expect.equal "hamburger"
-            , test "should serialize an Prefix expression into string" <|
-                \_ ->
-                    serializeExprWithOutExplicitOr (Prefix "hamburger")
-                        |> Expect.equal "hamburger*"
-            , test "should serialize an Exclude expression with a Word expression into string" <|
-                \_ ->
-                    serializeExprWithOutExplicitOr (Exclude (Word "hamburger"))
-                        |> Expect.equal "-hamburger"
-            , test "should serialize an Exclude expression with a Prefix expression into string" <|
-                \_ ->
-                    serializeExprWithOutExplicitOr (Exclude (Prefix "big"))
-                        |> Expect.equal "-big*"
-            , test "should serialize an Exclude expression with a group expression into string" <|
-                \_ ->
-                    serializeExprWithOutExplicitOr (Exclude (Or (Prefix "big") (Exact "french fries")))
-                        |> Expect.equal "-(big* | \"french fries\")"
-            , test "should serialize an And Expression into string" <|
-                \_ ->
-                    serializeExprWithOutExplicitOr (And (Word "hamburger") (Prefix "cheese"))
-                        |> Expect.equal "hamburger cheese*"
-            , test "should serialize a Or expression into string" <|
-                \_ ->
-                    serializeExprWithOutExplicitOr (Or (Prefix "bread") (Exclude (Word "vegetable")))
-                        |> Expect.equal "bread* | -vegetable"
-            , test "should serialize a group expression into a string" <|
-                \_ ->
-                    serializeExprWithOutExplicitOr (And (Prefix "big") (Or (Word "potatoes") (Exact "french fries")))
-                        |> Expect.equal "big* (potatoes | \"french fries\")"
-            , test "should serialize a nested AND group expression into a string" <|
-                \_ ->
-                    serializeExprWithOutExplicitOr (Or (Prefix "big") (And (Word "potatoes") (And (Word "ketchup") (Word "mayo"))))
-                        |> Expect.equal "big* | potatoes ketchup mayo"
-            , test "should serialize a nested OR group expression into a string" <|
-                \_ ->
-                    serializeExprWithOutExplicitOr
-                        (And
-                            (Or (Word "potatoes") (Word "fries"))
-                            (And
-                                (Word "onions")
-                                (Or (Word "ketchup") (Word "mayo"))
-                            )
-                        )
-                        |> Expect.equal "(potatoes | fries) onions (ketchup | mayo)"
-            ]
+        [ test "should serialize an Word expression into string" <|
+            \_ ->
+                Elastic.serialize (Word "hamburger")
+                    |> Expect.equal "hamburger"
+        , test "should serialize an Prefix expression into string" <|
+            \_ ->
+                Elastic.serialize (Prefix "hamburger")
+                    |> Expect.equal "hamburger*"
+        , test "should serialize an Exclude expression with a Word expression into string" <|
+            \_ ->
+                Elastic.serialize (Exclude (Word "hamburger"))
+                    |> Expect.equal "-hamburger"
+        , test "should serialize an Exclude expression with a Prefix expression into string" <|
+            \_ ->
+                Elastic.serialize (Exclude (Prefix "big"))
+                    |> Expect.equal "-big*"
+        , test "should serialize an Exclude expression with a group expression into string" <|
+            \_ ->
+                Elastic.serialize (Exclude (Or [ Prefix "big", Exact "french fries" ]))
+                    |> Expect.equal "-(big* | \"french fries\")"
+        , test "should serialize an And Expression into string" <|
+            \_ ->
+                Elastic.serialize (And [ Word "hamburger", Prefix "cheese" ])
+                    |> Expect.equal "hamburger cheese*"
+        , test "should serialize a Or expression with implicit parenthesis into string" <|
+            \_ ->
+                Elastic.serialize (Or [ Prefix "bread", Exclude (Word "vegetable") ])
+                    |> Expect.equal "bread* | -vegetable"
+        , test "should serialize a group expression into a string" <|
+            \_ ->
+                Elastic.serialize (And [ Prefix "big", Or [ Word "potatoes", Exact "french fries" ] ])
+                    |> Expect.equal "big* (potatoes | \"french fries\")"
+        , test "should serialize a nested AND group expression into a string" <|
+            \_ ->
+                Elastic.serialize (Or [ Prefix "big", And [ Word "potatoes", Word "ketchup", Word "mayo" ] ])
+                    |> Expect.equal "big* | potatoes ketchup mayo"
+        , test "should serialize a nested OR group expression into a string" <|
+            \_ ->
+                Elastic.serialize
+                    (And
+                        [ Or [ Word "potatoes", Word "fries" ]
+                        , And
+                            [ Word "onions"
+                            , Or [ Word "ketchup", Word "mayo" ]
+                            ]
+                        ]
+                    )
+                    |> Expect.equal "(potatoes | fries) onions (ketchup | mayo)"
         ]

--- a/tests/SerializerTest.elm
+++ b/tests/SerializerTest.elm
@@ -7,13 +7,13 @@ import Test exposing (..)
 
 
 serializeExprWithExplicitOr : Expr -> String
-serializeExprWithExplicitOr expr =
-    serializeExpr { explicitOr = True } expr
+serializeExprWithExplicitOr =
+    serializeExpr { explicitOr = True }
 
 
 serializeExprWithOutExplicitOr : Expr -> String
-serializeExprWithOutExplicitOr expr =
-    serializeExpr { explicitOr = False } expr
+serializeExprWithOutExplicitOr =
+    serializeExpr { explicitOr = False }
 
 
 suite : Test
@@ -39,7 +39,7 @@ suite =
             , test "should serialize an Exclude expression with a group expression into string" <|
                 \_ ->
                     serializeExprWithExplicitOr (Exclude (Or (Prefix "big") (Exact "french fries")))
-                        |> Expect.equal "-((big*) | (\"french fries\"))"
+                        |> Expect.equal "-(big* | \"french fries\")"
             , test "should serialize an And Expression into string" <|
                 \_ ->
                     serializeExprWithExplicitOr (And (Word "hamburger") (Prefix "cheese"))
@@ -47,11 +47,26 @@ suite =
             , test "should serialize a Or expression with implicit parenthesis into string" <|
                 \_ ->
                     serializeExprWithExplicitOr (Or (Prefix "bread") (Exclude (Word "vegetable")))
-                        |> Expect.equal "(bread*) | (-vegetable)"
+                        |> Expect.equal "bread* | -vegetable"
             , test "should serialize a group expression into a string" <|
                 \_ ->
                     serializeExprWithExplicitOr (And (Prefix "big") (Or (Word "potatoes") (Exact "french fries")))
-                        |> Expect.equal "big* ((potatoes) | (\"french fries\"))"
+                        |> Expect.equal "big* (potatoes | \"french fries\")"
+            , test "should serialize a nested AND group expression into a string" <|
+                \_ ->
+                    serializeExprWithExplicitOr (Or (Prefix "big") (And (Word "potatoes") (And (Word "ketchup") (Word "mayo"))))
+                        |> Expect.equal "big* | potatoes ketchup mayo"
+            , test "should serialize a nested OR group expression into a string" <|
+                \_ ->
+                    serializeExprWithExplicitOr
+                        (And
+                            (Or (Word "potatoes") (Word "fries"))
+                            (And
+                                (Word "onions")
+                                (Or (Word "ketchup") (Word "mayo"))
+                            )
+                        )
+                        |> Expect.equal "(potatoes | fries) onions (ketchup | mayo)"
             ]
         , describe "serializeExpr without explicitOr"
             [ test "should serialize an Word expression into string" <|
@@ -86,5 +101,20 @@ suite =
                 \_ ->
                     serializeExprWithOutExplicitOr (And (Prefix "big") (Or (Word "potatoes") (Exact "french fries")))
                         |> Expect.equal "big* (potatoes | \"french fries\")"
+            , test "should serialize a nested AND group expression into a string" <|
+                \_ ->
+                    serializeExprWithOutExplicitOr (Or (Prefix "big") (And (Word "potatoes") (And (Word "ketchup") (Word "mayo"))))
+                        |> Expect.equal "big* | potatoes ketchup mayo"
+            , test "should serialize a nested OR group expression into a string" <|
+                \_ ->
+                    serializeExprWithOutExplicitOr
+                        (And
+                            (Or (Word "potatoes") (Word "fries"))
+                            (And
+                                (Word "onions")
+                                (Or (Word "ketchup") (Word "mayo"))
+                            )
+                        )
+                        |> Expect.equal "(potatoes | fries) onions (ketchup | mayo)"
             ]
         ]


### PR DESCRIPTION
This patch updates the code to experiment with distinct data structures for AST and expressions, in order to ease serialization as well as expressing multiple AND/OR statements using a `List`.

So instead of writing

```elm
And (Word "a") (And (Word "b") (And (Word "c") (Word "d")))
```

You now write

```elm
And [ Word "a", Word "b", Word "c", Word "d" ]
```

Which is easier to read, maintain and serialize.

I've also removed the `explicitOr` option as I couldn't figure out how to leverage it efficiently. I've found it was mostly adding noise with unecessary nested parenthesis with no real better precedence handling (we're already wrapping OR statements around parenthesis). But maybe I'm missing the use case we've initially added this option for.

I'm not gonna bug fbentz during his holidays so I'm asking @rtxm for feedback here. 