### PR TITLE
Handle fuzzy search

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
         - gh-pages
 
     docker:
-      - image: circleci/node:lts-stretch
+      - image: circleci/node:13.3-stretch
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
         - gh-pages
 
     docker:
-      - image: circleci/node:13.3-stretch
+      - image: circleci/node:11
 
     steps:
       - checkout

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ string search queries out of it.
 
 **Notes:**
 
-  - `~N` operator is not supported.
   - Serialization will enforce classic boolean operator precedence by using
     parenthesis groups everywhere applicable.
 
@@ -23,6 +22,7 @@ string search queries out of it.
     \+ AND
     -- Exclude
     "" Exact
+    ~n Fuzzy
     \* Prefix
 
 Specific case : Spaces (signifying in some contexts and not in others)
@@ -34,6 +34,7 @@ type Expr
     = And (List Expr)
     | Exact String
     | Exclude Expr
+    | Fuzzy Int String
     | Or (List Expr)
     | Prefix String
     | Word String
@@ -47,7 +48,7 @@ Unless explicitly indicated, spaces are ignored.
     ORExpr => ANDExpr | ANDExpr "|" ORExpr
     ANDExpr => EXCExpr | EXCExpr ("+"|\s+) ANDExpr
     EXCExpr => "-" GRPExpr | GRPExpr
-    GRPExpr => WORD~"\*" | WORD | \" EXACTExpr \" | "(" ORExpr ")"
+    GRPExpr => WORD~"\*" | WORD~"\~2" | WORD | \" EXACTExpr \" | "(" ORExpr ")"
     EXACTExpr => [^"]+
 
 ## Example

--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "allo-media/elm-es-simple-query-string",
     "summary": "Parse and serialize ElasticSearch search strings.",
     "license": "MIT",
-    "version": "2.0.0",
+    "version": "3.0.0",
     "exposed-modules": [
         "Elastic"
     ],

--- a/src/Elastic.elm
+++ b/src/Elastic.elm
@@ -195,37 +195,20 @@ parseExpr =
         |. Parser.end
 
 
-type ParsedWord
-    = Simple
-    | Prefixed
-    | Fuzzied Int
-
-
 singleWordExpr : Parser Expr
 singleWordExpr =
-    Parser.succeed
-        (\word kind ->
-            case kind of
-                Simple ->
-                    Word word
-
-                Prefixed ->
-                    Prefix word
-
-                Fuzzied level ->
-                    Fuzzy level word
-        )
+    Parser.succeed (\word toExpr -> toExpr word)
         |= Parser.variable
             { start = isWordChar
             , inner = isWordChar
             , reserved = Set.fromList []
             }
         |= Parser.oneOf
-            [ Parser.map (\_ -> Prefixed) (Parser.symbol "*")
-            , Parser.succeed Fuzzied
+            [ Parser.map (\_ -> Prefix) (Parser.symbol "*")
+            , Parser.succeed Fuzzy
                 |. Parser.symbol "~"
                 |= Parser.int
-            , Parser.succeed Simple
+            , Parser.succeed Word
             ]
 
 

--- a/src/Elastic.elm
+++ b/src/Elastic.elm
@@ -153,11 +153,7 @@ groupExpr : Parser Expr
 groupExpr =
     Parser.oneOf
         [ exactExpr
-
-        -- , fuzzyExpr
-        -- , prefixExpr
-        , prefixOrWord
-        , wordExpr
+        , singleWordExpr
         , Parser.succeed identity
             |. Parser.symbol "("
             |. Parser.spaces
@@ -205,8 +201,8 @@ type ParsedWord
     | Fuzzied Int
 
 
-prefixOrWord : Parser Expr
-prefixOrWord =
+singleWordExpr : Parser Expr
+singleWordExpr =
     Parser.succeed
         (\word kind ->
             case kind of
@@ -231,16 +227,6 @@ prefixOrWord =
                 |= Parser.int
             , Parser.succeed Simple
             ]
-
-
-wordExpr : Parser Expr
-wordExpr =
-    Parser.succeed Word
-        |= Parser.variable
-            { start = isWordChar
-            , inner = isWordChar
-            , reserved = Set.fromList []
-            }
 
 
 pureExclude : Parser Expr

--- a/tests/Suite.elm
+++ b/tests/Suite.elm
@@ -30,6 +30,12 @@ suite =
             , Elastic.parse "a*"
                 |> Expect.equal (Ok (Prefix "a"))
                 |> asTest "should parse a Prefix expression"
+            , Elastic.parse "a~2"
+                |> Expect.equal (Ok (Fuzzy 2 "a"))
+                |> asTest "should parse a fuzzy match expression"
+            , Elastic.parse "-a~2"
+                |> Expect.equal (Ok (Exclude (Fuzzy 2 "a")))
+                |> asTest "should parse an excluded fuzzy match expression"
             , Elastic.parse "-a"
                 |> Expect.equal (Ok (Exclude (Word "a")))
                 |> asTest "should parse an Exclude expression"
@@ -107,12 +113,18 @@ suite =
             , Elastic.serialize (Prefix "a")
                 |> Expect.equal "a*"
                 |> asTest "should serialize an Prefix expression into string"
+            , Elastic.serialize (Fuzzy 2 "a")
+                |> Expect.equal "a~2"
+                |> asTest "should serialize a Fuzzy expression into string"
             , Elastic.serialize (Exclude (Word "a"))
                 |> Expect.equal "-a"
                 |> asTest "should serialize an Exclude expression with a Word expression into string"
             , Elastic.serialize (Exclude (Prefix "a"))
                 |> Expect.equal "-a*"
                 |> asTest "should serialize an Exclude expression with a Prefix expression into string"
+            , Elastic.serialize (Exclude (Fuzzy 2 "a"))
+                |> Expect.equal "-a~2"
+                |> asTest "should serialize an Exclude expression with a Fuzzy expression into string"
             , Elastic.serialize (Exclude (Or [ Prefix "a", Exact "b c" ]))
                 |> Expect.equal "-(a* | \"b c\")"
                 |> asTest "should serialize an Exclude expression with a group expression into string"


### PR DESCRIPTION
This patch adds support for ES fuzzy search operator. 

```
$ elm diff
This is a MAJOR change.

---- Elastic - MAJOR ----

    Changed:
      - type Expr 
            = And (List Expr)
            | Exact String
            | Exclude Expr
            | Or (List Expr)
            | Prefix String
            | Word String
      + type Expr 
            = And (List.List Elastic.Expr)
            | Exact String.String
            | Exclude Elastic.Expr
            | Fuzzy Basics.Int String.String
            | Or (List.List Elastic.Expr)
            | Prefix String.String
            | Word String.String

```